### PR TITLE
Resolves #13; apsctl check now uses wildcards

### DIFF
--- a/Jamf Environment Test.sh
+++ b/Jamf Environment Test.sh
@@ -1015,7 +1015,7 @@ function calculateAdditionalChecks () {
 	#apsctl Status
 	echo "[step] Checking APNS Status"
 	APSCTL_STATUS_CHECK=$(/System/Library/PrivateFrameworks/ApplePushService.framework/apsctl status | /usr/bin/grep "server hostname:")
-		if [[ ${APSCTL_STATUS_CHECK} =~ "courier.push.apple.com" ]]; then
+		if [[ ${APSCTL_STATUS_CHECK} == *"courier.push.apple.com"* ]]; then
 			APSCTL_STATUS='<td style="color: green;">Connected</td>'
 		else
 			APSCTL_STATUS='<td style="color: red;">Unavailable</td>'


### PR DESCRIPTION
Credit to @MacTool for the [recommendation and resolution](https://github.com/jamf/Jamf-Environment-Test/issues/13#issuecomment-2035366238). 

Performed testing of the script after the change on the following, all of which recorded the APNS status correctly:
- Silicon MBP running 14.4.1
- Intel Mac Mini running 14.4.1
- Intel Mac Pro running 12.6.7